### PR TITLE
Implement support for XmlAttribute in WriteAttribute method

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -1981,9 +1981,12 @@ namespace System.Xml.Serialization
                 }
                 else if (special.TypeDesc.CanBeAttributeValue)
                 {
-                    // https://github.com/dotnet/runtime/issues/1398:
-                    // To Support special.TypeDesc.CanBeAttributeValue == true
-                    throw new NotImplementedException("special.TypeDesc.CanBeAttributeValue");
+                    if (attr is not XmlAttribute xmlAttribute)
+                    {
+                        return;
+                    }
+
+                    value = xmlAttribute;
                 }
                 else
                     throw new InvalidOperationException(SR.XmlInternalError);

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.Internal.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.Internal.cs
@@ -11,27 +11,6 @@ using Xunit;
 
 public static partial class XmlSerializerTests
 {
-    // Move this test to XmlSerializerTests.cs once #1398 is fixed for the ReflectionOnly serializer.
-    [Fact]
-    public static void Xml_CustomDocumentWithXmlAttributesAsNodes()
-    {
-        var customDoc = new CustomDocument();
-        var customElement = new CustomElement() { Name = "testElement" };
-        customElement.AddAttribute(customDoc.CreateAttribute("regularAttribute", "regularValue"));
-        customElement.AddAttribute(customDoc.CreateCustomAttribute("customAttribute", "customValue"));
-        customDoc.CustomItems.Add(customElement);
-        var element = customDoc.Document.CreateElement("regularElement");
-        var innerElement = customDoc.Document.CreateElement("innerElement");
-        innerElement.InnerXml = "<leafElement>innerText</leafElement>";
-        element.InnerText = "regularText";
-        element.AppendChild(innerElement);
-        element.Attributes.Append(customDoc.CreateAttribute("regularElementAttribute", "regularElementAttributeValue"));
-        customDoc.AddItem(element);
-        var actual = SerializeAndDeserialize(customDoc,
-            WithXmlHeader(@"<customElement name=""testElement"" regularAttribute=""regularValue"" customAttribute=""customValue""/>"), skipStringCompare: true);
-        Assert.NotNull(actual);
-    }
-
     // Move this test to XmlSerializerTests.cs once #1401 is fixed for the ReflectionOnly serializer.
     [Fact]
     public static void Xml_DerivedIXmlSerializable()

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -626,6 +626,26 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
+    public static void Xml_CustomDocumentWithXmlAttributesAsNodes()
+    {
+        var customDoc = new CustomDocument();
+        var customElement = new CustomElement() { Name = "testElement" };
+        customElement.AddAttribute(customDoc.CreateAttribute("regularAttribute", "regularValue"));
+        customElement.AddAttribute(customDoc.CreateCustomAttribute("customAttribute", "customValue"));
+        customDoc.CustomItems.Add(customElement);
+        var element = customDoc.Document.CreateElement("regularElement");
+        var innerElement = customDoc.Document.CreateElement("innerElement");
+        innerElement.InnerXml = "<leafElement>innerText</leafElement>";
+        element.InnerText = "regularText";
+        element.AppendChild(innerElement);
+        element.Attributes.Append(customDoc.CreateAttribute("regularElementAttribute", "regularElementAttributeValue"));
+        customDoc.AddItem(element);
+        var actual = SerializeAndDeserialize(customDoc,
+            WithXmlHeader(@"<customElement name=""testElement"" regularAttribute=""regularValue"" customAttribute=""customValue""/>"), skipStringCompare: true);
+        Assert.NotNull(actual);
+    }
+
+    [Fact]
     public static void Xml_Struct()
     {
         var value = new WithStruct { Some = new SomeStruct { A = 1, B = 2 } };


### PR DESCRIPTION
Add support for `XmlAttribute` in the `WriteAttribute` method and include a corresponding test to validate the functionality. This change addresses issue #1398 related to XML serialization.